### PR TITLE
Handle arrays of non-pointers

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -534,10 +534,14 @@ function includePaths(object, pathsRemaining) {
 
   if (target) {
     if (Array.isArray(target)) {
-      object[path] = target.map(pointer => {
-        const fetched = fetchObjectByPointer(pointer);
-        includePaths(fetched, _.cloneDeep(pathsRemaining));
-        return fetched;
+      object[path] = target.map(item => {
+        if (item.className) {
+          // This is a pointer or an object
+          const fetched = fetchObjectByPointer(item);
+          includePaths(fetched, _.cloneDeep(pathsRemaining));
+          return fetched;
+        }
+        return item;
       });
     } else {
       if (object[path].__type === 'Pointer') {

--- a/test/test.js
+++ b/test/test.js
@@ -1029,6 +1029,21 @@ describe('ParseMock', () => {
     });
   });
 
+  it('should handle includes for array of string', () => {
+    const item = new Item({ alternateNames: ['item1', 'originalItem'] });
+    return Parse.Object.saveAll([item]).then(() => {
+      const brand = new Brand({
+        item,
+      });
+      return brand.save();
+    }).then(() => {
+      const q = new Parse.Query(Brand).include('item,item.alternateNames');
+      return q.first();
+    }).then((brand) => {
+      assert.deepEqual(brand.get('item').get('alternateNames'), ['item1', 'originalItem']);
+    });
+  });
+
   it('should handle includes where item is missing', () => {
     const item = new Item({ cool: true });
     const brand1 = new Brand({});


### PR DESCRIPTION
It looks like we were assuming that any array stored on an object would be an array of pointers. But in fact, we sometimes have arrays of strings, and Parse handles that correctly but parse-mockdb doesn't.