### PR TITLE
Upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,9 +1003,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Hustle/parse-mockdb",
   "dependencies": {
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.11",
     "parse-shim": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
When running `npm audit fix` this is one of the fixes that gets applied. The other fixes cause some test breakages so I'll look into those separately.