### PR TITLE
Proposed Release: v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install parse-mockdb --save-dev
 const Parse = require('parse-shim');
 const ParseMockDB = require('parse-mockdb');
 
-ParseMockDB.mockDB(); // Mock the Parse RESTController
+ParseMockDB.mockDB(Parse); // Mock the Parse RESTController
 
 // Perform saves, queries, updates, deletes, etc... using the Parse JS SDK
 
@@ -40,6 +40,9 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 ### Changelog
 
 #### Pending release
+- *Breaking Change* When calling `mockDB()` you must now pass in a reference to
+  the Parse SDK that you want to mock.
+
 - *Breaking Change* Stopped patching MockDB object on to Parse module. You can no longer
   access `Parse.MockDB`, you must load the `parse-mockdb` module explicitly.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 
 ### Changelog
 
-#### Pending release
+#### v0.3.0
 - *Breaking Change* When calling `mockDB()` you must now pass in a reference to
   the Parse SDK that you want to mock.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
  - [ ] Parse special classes (Parse.User, Parse.Role, ...)
  - [ ] Parse lifecycle hooks (beforeSave - done, afterSave - done, beforeDelete - done, afterDelete)
 
+
+### Changelog
+
+#### Pending release
+- *Breaking Change* Removed ParseMockDB.promiseResultSync method
+
+
 ### Tests
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 ### Changelog
 
 #### Pending release
+- *Breaking Change* Stopped patching MockDB object on to Parse module. You can no longer
+  access `Parse.MockDB`, you must load the `parse-mockdb` module explicitly.
+
 - *Breaking Change* Removed ParseMockDB.promiseResultSync method
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "parse-mockdb",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
-  "preserveSymlinks": "1",
   "requires": true,
   "dependencies": {
     "acorn": {
@@ -117,6 +116,7 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
       "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.10.0"
@@ -237,7 +237,8 @@
     "core-js": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1214,18 +1215,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/parse/-/parse-1.10.0.tgz",
       "integrity": "sha1-Ul5GOrogy0giiGe746Erv21mhWA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.11.6",
         "ws": "^2.2.3",
         "xmlhttprequest": "^1.7.0"
-      }
-    },
-    "parse-shim": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-shim/-/parse-shim-1.0.6.tgz",
-      "integrity": "sha1-+2KF4BO1qWX51m1LrdtjCqLfMno=",
-      "requires": {
-        "parse": ">= 1.6.0"
       }
     },
     "path-exists": {
@@ -1364,7 +1358,8 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -1428,7 +1423,8 @@
     "safe-buffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.7.8",
@@ -1603,7 +1599,8 @@
     "ultron": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "dev": true
     },
     "user-home": {
       "version": "2.0.0",
@@ -1645,6 +1642,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
       "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.0.1",
         "ultron": "~1.1.0"
@@ -1653,7 +1651,8 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-mockdb",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "homepage": "https://github.com/Hustle/parse-mockdb",
   "dependencies": {
-    "lodash": "^4.17.11",
-    "parse-shim": "^1.0.6"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "eslint": "^3.4.0",
@@ -36,7 +35,8 @@
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.2.0",
     "eslint-plugin-react": "^6.2.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "parse": "^1.7.0"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-mockdb",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Parse JS SDK Mocked Database",
   "main": "src/parse-mockdb.js",
   "engines": {

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -819,15 +819,6 @@ function handleDeleteRequest(request) {
   });
 }
 
-// **HACK** Makes testing easier.
-function promiseResultSync(promise) {
-  let result;
-  promise.then(res => {
-    result = res;
-  });
-  return result;
-}
-
 const HANDLERS = {
   GET: handleGetRequest,
   POST: handlePostRequest,
@@ -884,7 +875,6 @@ Parse.MockDB = {
   mockDB,
   unMockDB,
   cleanUp,
-  promiseResultSync,
   registerHook,
   mockUser,
 };

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Parse = require('parse-shim');
 const _ = require('lodash');
 
 const crypto = require('./crypto');
@@ -12,6 +11,7 @@ const CONFIG = {
   DEBUG: process.env.DEBUG_DB,
 };
 
+let Parse;
 let db = {};
 let hooks = {};
 const masks = {};
@@ -853,7 +853,8 @@ const MockRESTController = {
  * Mocks a Parse API server, by intercepting requests and storing/querying data locally
  * in an in-memory DB.
  */
-function mockDB() {
+function mockDB(parseModule) {
+  Parse = parseModule;
   if (!mocked) {
     defaultController = Parse.CoreManager.getRESTController();
     mocked = true;

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -871,7 +871,7 @@ function unMockDB() {
   }
 }
 
-Parse.MockDB = {
+const MockDB = {
   mockDB,
   unMockDB,
   cleanUp,
@@ -879,4 +879,4 @@ Parse.MockDB = {
   mockUser,
 };
 
-module.exports = Parse.MockDB;
+module.exports = MockDB;

--- a/test/test.js
+++ b/test/test.js
@@ -333,7 +333,7 @@ function sleep(ms) {
 
 describe('ParseMock', () => {
   beforeEach(() => {
-    ParseMockDB.mockDB();
+    ParseMockDB.mockDB(Parse);
   });
 
   afterEach(() => {

--- a/test/test.js
+++ b/test/test.js
@@ -333,11 +333,11 @@ function sleep(ms) {
 
 describe('ParseMock', () => {
   beforeEach(() => {
-    Parse.MockDB.mockDB();
+    ParseMockDB.mockDB();
   });
 
   afterEach(() => {
-    Parse.MockDB.cleanUp();
+    ParseMockDB.cleanUp();
   });
 
   context('supports Parse.User subclasses', () => {


### PR DESCRIPTION
Due to our usage of `parse-shim` as the dependency from which we import `Parse`, making version changes to the Parse JS SDK is challenging. We can avoid some of the tricky dependency pain by having consumers of this library pass the Parse module they are using in to the `mockDB` call.

This is a little more work for the caller, but I believe that the pain saved in dependency management makes this a worthwhile tradeoff.

As long as I'm making breaking changes, I bundled in fixes for some other warts:
- Remove an unused method that awkwardly tries to unwrap a promise
- Stop patching MockDB directly onto the `Parse` object

I'll be following up shortly with a v0.4.0 that is applied on top of these changes and switches to the 2.x series SDK.