### PR TITLE
Support v2.x Parse JS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 
 ### Changelog
 
-### Pending release
+### v0.4.0
 
 - *Breaking Change* This library is now targeting the 2.x series of the Parse JS SDK. If you are
   using Parse 1.6+, you should pin to the v0.3.x release.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Parse MockDB
 
 Master Build Status: [![Circle CI](https://circleci.com/gh/Hustle/parse-mockdb/tree/master.svg?style=svg)](https://circleci.com/gh/Hustle/parse-mockdb/tree/master)
 
-Provides a mocked Parse RESTController compatible with version `1.6+` of the JavaScript SDK.
+Provides a mocked Parse RESTController compatible with version `2.0+` of the JavaScript SDK.
 
 ### Installation and Usage
 
@@ -38,6 +38,11 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 
 
 ### Changelog
+
+### Pending release
+
+- *Breaking Change* This library is now targeting the 2.x series of the Parse JS SDK. If you are
+  using Parse 1.6+, you should pin to the v0.3.x release.
 
 #### v0.3.0
 - *Breaking Change* When calling `mockDB()` you must now pass in a reference to

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.7.tgz",
+      "integrity": "sha512-kr3W3Fw8mB/CTru2M5zIRQZZgC/9zOxNSoJ/tVCzjPt3H1/p5uuGbz6WwmaQy/TLQcW31rUhUUWKY28sXFRelA==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "acorn": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
@@ -110,16 +129,6 @@
         "chalk": "^1.1.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
       }
     },
     "balanced-match": {
@@ -234,16 +243,22 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+    "core-js-pure": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
       "dev": true
     },
     "d": {
@@ -1212,14 +1227,17 @@
       "dev": true
     },
     "parse": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-1.10.0.tgz",
-      "integrity": "sha1-Ul5GOrogy0giiGe746Erv21mhWA=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-2.11.0.tgz",
+      "integrity": "sha512-dbGdA5M1ylky4T/b5pOXeYhsHwzATz/JbweCiBtdJLsnb8SylSSgA7V0U96RtXBI1Hfzp5uFZpqmnUKr5t69NA==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.11.6",
-        "ws": "^2.2.3",
-        "xmlhttprequest": "^1.7.0"
+        "@babel/runtime": "7.7.7",
+        "@babel/runtime-corejs3": "7.7.7",
+        "crypto-js": "3.1.9-1",
+        "uuid": "3.3.3",
+        "ws": "7.2.1",
+        "xmlhttprequest": "1.8.0"
       }
     },
     "path-exists": {
@@ -1356,9 +1374,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
       "dev": true
     },
     "require-uncached": {
@@ -1418,12 +1436,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
-    },
-    "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
       "dev": true
     },
     "shelljs": {
@@ -1596,12 +1608,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
-      "dev": true
-    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -1615,6 +1621,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "wordwrap": {
@@ -1639,14 +1651,10 @@
       }
     },
     "ws": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "dev": true
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-mockdb",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.0",
     "eslint-plugin-react": "^6.2.0",
     "mocha": "^2.2.5",
-    "parse": "^1.7.0"
+    "parse": "^2.0.0"
   },
   "directories": {
     "test": "test"
@@ -60,6 +60,6 @@
     }
   },
   "peerDependencies": {
-    "parse": "^1.7.0"
+    "parse": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-mockdb",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Parse JS SDK Mocked Database",
   "main": "src/parse-mockdb.js",
   "engines": {


### PR DESCRIPTION
The main difference is that we now return native promises, as Parse.Promise is removed in the 2.x SDK, so we also need to return native promises.